### PR TITLE
Indicate test result in return value

### DIFF
--- a/include/CppSpec.h
+++ b/include/CppSpec.h
@@ -31,8 +31,7 @@
 #define CPPSPEC_MAIN \
 	int main(int argc, char* argv[]) { \
         CppSpec::SpecRunner runner(argc, argv); \
-		runner.runSpecifications(); \
-		return 0; \
+		return runner.runSpecifications() ? 1 : 0;	\
 	}
 
 

--- a/include/Runnable.h
+++ b/include/Runnable.h
@@ -34,7 +34,7 @@ public:
 	/**
 	 * Execute behaviors of a specification
 	 */
-	virtual void operator()(Reporter* reporter) = 0;
+	virtual bool operator()(Reporter* reporter) = 0;
 
 	/**
 	 * Get the name of the specification.

--- a/include/SpecRunner.h
+++ b/include/SpecRunner.h
@@ -22,13 +22,13 @@ public:
     virtual ~SpecRunner();
 
 public:
-    void runSpecifications();
+    bool runSpecifications();
     friend class SpecRunnerTestAccessor;
 
 private:
     OutputStream* createOutputStream();
     Reporter* createReporter(OutputStream& outputStream);
-    void runSpecs(const std::vector<std::string>& specifications, Reporter* reporter);
+    bool runSpecs(const std::vector<std::string>& specifications, Reporter* reporter);
 
 private:
     boost::program_options::variables_map* arguments;

--- a/include/Specification.h
+++ b/include/Specification.h
@@ -101,7 +101,7 @@ public: // Expectations, these are used through specify-macro
 	}
 
 public: // from Runnable
-	void operator()(Reporter* reporter) {
+	bool operator()(Reporter* reporter) {
 		reporter->specificationStarted(*this);
 		const int count(SpecificationBase<Derived>::behaviors.size());
 		for(int i = 0; i < count; ++i) {
@@ -111,6 +111,7 @@ public: // from Runnable
 			static_cast<Derived*>(this)->destroyContext();
 		}
 		reporter->specificationEnded(SpecificationBase<Derived>::getName());
+		return SpecificationBase<Derived>::failed;
 	}
 
 public: // Vocabulary
@@ -138,7 +139,7 @@ public:
     }
 
 public: // from Runnable
-    void operator()(Reporter* reporter) {
+    bool operator()(Reporter* reporter) {
         reporter->specificationStarted(*this);
         const int count(SpecificationBase<Derived>::behaviors.size());
         for(int i = 0; i < count; ++i) {
@@ -146,6 +147,7 @@ public: // from Runnable
             SpecificationBase<Derived>::executeBehavior(behavior, reporter);
         }
         reporter->specificationEnded(SpecificationBase<Derived>::getName());
+        return SpecificationBase<Derived>::failed;
     }
 
 public:

--- a/include/SpecificationBase.h
+++ b/include/SpecificationBase.h
@@ -34,7 +34,7 @@ namespace CppSpec {
 template<class Derived>
 class SpecificationBase : public Runnable {
 public:
-    SpecificationBase() : behaviors(), name(TypeNameResolver().getTypename<Derived>()) {
+    SpecificationBase() : behaviors(), failed(false), name(TypeNameResolver().getTypename<Derived>()) {
         SpecificationRegistry::instance().addSpecification(this);
     }
 
@@ -95,14 +95,17 @@ protected:
             reporter->behaviorSucceeded();
         }
         catch (SpecifyFailedException& e) {
+            failed = true;
             reporter->behaviorFailed(e.file, e.line, e.message);
         }
         catch (std::exception& e) {
+            failed = true;
             std::stringstream msg;
             msg << TypeNameResolver().getTypename(e) << "[" << e.what() << "] occured in " << behavior.getName();
             reporter->behaviorFailed("", 0, msg.str());
         }
         catch (...) {
+            failed = true;
             std::stringstream msg;
             msg << "An exception occured in " << behavior.getName();
             reporter->behaviorFailed("", 0, msg.str());
@@ -128,6 +131,7 @@ private:
 protected:
     typedef std::vector<Functor*> BehaviorList;
     BehaviorList behaviors;
+    bool failed;
 
 private:
     SpecificationBase(const SpecificationBase&);

--- a/src/SpecRunner.cpp
+++ b/src/SpecRunner.cpp
@@ -64,16 +64,17 @@ SpecRunner::~SpecRunner() {
     delete arguments;
 }
 
-void SpecRunner::runSpecifications() {
+bool SpecRunner::runSpecifications() {
     Needle::Binder::instance().bind<Timer>(new BoostTimer());
 
     OutputStream* outputStream = createOutputStream();
     Reporter* reporter = createReporter(*outputStream);
 
-    runSpecs(specificationsToRun, reporter);
+    bool failed = runSpecs(specificationsToRun, reporter);
 
     delete reporter;
     delete outputStream;
+    return failed;
 }
 
 OutputStream* SpecRunner::createOutputStream() {
@@ -100,13 +101,17 @@ Reporter* SpecRunner::createReporter(OutputStream& outputStream) {
     return new SpecDoxReporter(outputStream);
 }
 
-void SpecRunner::runSpecs(const std::vector<std::string>& specificationsToRun, Reporter* reporter) {
+bool SpecRunner::runSpecs(const std::vector<std::string>& specificationsToRun, Reporter* reporter) {
     ShouldBeRun shouldBeRun(specificationsToRun);
+    bool failed = false;
     BOOST_FOREACH(Runnable* specification, SpecificationRegistry::instance().getSpecifications()) {
         if(shouldBeRun(specification->getName())) {
-            (*specification)(reporter);
+            if ((*specification)(reporter)) {
+                failed = true;
+            }
         }
     }
+    return failed;
 }
 
 }


### PR DESCRIPTION
Hi,

Currently CppSpec returns 0, whatever the result of running specifications, making hard check if the tests were successfull, other than parsing the whole output of the program. I've modified CppSpec, so main() will return 1 if any of the specifications failed.
