### PR TITLE
Support for test method names with underscore instead of camelcase.

### DIFF
--- a/include/SpecDoxReporter.h
+++ b/include/SpecDoxReporter.h
@@ -33,7 +33,7 @@ public:
     bool anyBehaviorFailed() const;
 
 private:
-	std::string separateCamelCasedWords(const std::string& text);
+	std::string formatCamelCasedWordsAndUnderlines(const std::string& text);
 
 private:
     SpecDoxReporter(const SpecDoxReporter&);

--- a/src/SpecDoxReporter.cpp
+++ b/src/SpecDoxReporter.cpp
@@ -33,7 +33,7 @@ void SpecDoxReporter::addSpecification(const SpecResult &results) {
     int fail(0);
     outputStream << results.getSpecificationName() << ":" << "\n";
     for (std::vector<SpecResult::BehaviorResult>::const_iterator it = results.firstBehavior(); it != results.lastBehavior(); it++) {
-        outputStream << "  " << separateCamelCasedWords(it->name);
+        outputStream << "  " << formatCamelCasedWordsAndUnderlines(it->name);
         if (it->passed) {
             outputStream << "\n";
             ++pass;
@@ -50,14 +50,18 @@ bool SpecDoxReporter::anyBehaviorFailed() const {
     return anyFailed;
 }
     
-std::string SpecDoxReporter::separateCamelCasedWords(const std::string& text) {
+std::string SpecDoxReporter::formatCamelCasedWordsAndUnderlines(const std::string& text) {
 	std::string result;
 	std::string::iterator it = (const_cast<std::string&>(text)).begin();
 	while(it != text.end()) {
 		if(::isupper(*it)) {
 			result.append(" ");
 		}
-		result += ::tolower(*it);
+		if('_' == *it) {
+			result.append(" ");
+		} else {
+		  result += ::tolower(*it);
+    }
 		++it;
 	}
 	return result;


### PR DESCRIPTION
Some developer prefer the std library method naming style (with underscore) over the java style (CamelCase). This Pull request provides nice output also for testcase names with underscore.
